### PR TITLE
use nodeChildren option when determining relationship

### DIFF
--- a/dist/js/jquery.orgchart.js
+++ b/dist/js/jquery.orgchart.js
@@ -75,7 +75,7 @@
       if (data instanceof $) { // ul datasource
         buildHierarchy($chart, buildJsonDS(data.children()), 0, opts);
       } else { // local json datasource
-        buildHierarchy($chart, opts.ajaxURL ? data : attachRel(data, '00'), 0, opts);
+        buildHierarchy($chart, opts.ajaxURL ? data : attachRel(data, '00', opts), 0, opts);
       }
     } else {
       $.ajax({
@@ -86,7 +86,7 @@
         }
       })
       .done(function(data, textStatus, jqXHR) {
-        buildHierarchy($chart, opts.ajaxURL ? data : attachRel(data, '00'), 0, opts);
+        buildHierarchy($chart, opts.ajaxURL ? data : attachRel(data, '00', opts), 0, opts);
       })
       .fail(function(jqXHR, textStatus, errorThrown) {
         console.log(errorThrown);
@@ -230,11 +230,12 @@
     return subObj;
   }
 
-  function attachRel(data, flags) {
-    data.relationship = flags + (data.children ? 1 : 0);
-    if (data.children) {
-    data.children.forEach(function(item) {
-      attachRel(item, '1' + (data.children.length > 1 ? 1 :0));
+  function attachRel(data, flags, opts) {
+    var children = data[opts.nodeChildren]
+    data.relationship = flags + (children && children.length > 0 ? 1 : 0);
+    if (children) {
+    children.forEach(function(item) {
+      attachRel(item, '1' + (children.length > 1 ? 1 :0), opts);
     });
     }
     return data;


### PR DESCRIPTION
I found a bug if you override the nodeChildren option with a different value, the attatchRel() function doesn't use the new value, it is hardcoded to just use the default '.children'. This causes all of the expand arrows to be hidden. Modified that function to accept opts and use the overridden value.

Also made sure children.length is > 0 when setting relationship on line 235, if you have children specified in your object but it's an empty array, it sets it to 1 and the down arrow is created though there are no children. Clicking it then causes an error.