### PR TITLE
Fixed issues calling addChildren on root node

### DIFF
--- a/dist/js/jquery.orgchart.js
+++ b/dist/js/jquery.orgchart.js
@@ -487,7 +487,8 @@
   }
 
   function repaint(node) {
-    node.style.offsetWidth = node.offsetWidth;
+	if (node)
+      node.style.offsetWidth = node.offsetWidth;
   }
 
   // create node
@@ -812,6 +813,7 @@
   }
   // exposed method
   function addChildren($node, data, opts) {
+    var opts = opts || $node.closest('.orgchart').data('options');
     var count = 0;
     buildChildNode.call($node.closest('.orgchart').parent(), $node.closest('table'), data, opts, function() {
       if (++count === data.children.length) {


### PR DESCRIPTION
While experimenting with the `jquery.orgchart` plugin, I came across two issues that prevented adding children to the root node (which have been fixed in this request):

1. `function addChildren` errors out if `opts` is not passed as a parameter. This is alleviated by setting `opts` in the same manner used in `function buildChildNode`
2. `function repaint` errors out if `node` is undefined. As sanity check to verify that `node` is defined provides a simple fix.