### PR TITLE
Resolve issue so the passed relationship information for a node

### DIFF
--- a/dist/js/jquery.orgchart.js
+++ b/dist/js/jquery.orgchart.js
@@ -922,7 +922,7 @@
         $orgchart.triggerHandler({ 'type': 'nodedropped.orgchart', 'draggedNode': $dragged, 'dragZone': $dragZone.children(), 'dropZone': $dropZone });
       });
     }
-    // allow user to append dom modification after finishing node create of orgchart 
+    // allow user to append dom modification after finishing node create of orgchart
     if (opts.createNode) {
       opts.createNode($nodeDiv, nodeData);
     }
@@ -1027,7 +1027,7 @@
   function buildParentNode($currentRoot, nodeData, opts, callback) {
     var that = this;
     var $table = $('<table>');
-    nodeData.relationship = '001';
+    nodeData.relationship = nodeData.relationship || '001';
     $.when(createNode(nodeData, 0, opts || $currentRoot.closest('.orgchart').data('options')))
       .done(function($nodeDiv) {
         $table.append($nodeDiv.removeClass('slide-up').addClass('slide-down').wrap('<tr class="hidden"><td colspan="2"></td></tr>').closest('tr'));


### PR DESCRIPTION
When doing on-demand loading (via ajax), the 'relationship' was force-set to "001" even if it was already provided by the ajax / json.

The problem happens when the new parent has a relationship of  "111" or  "101"  (so the 'load parent' chevron should appear on the new parent).  This issue means  my dynamic generator could only go up one level instead of many.

This pull request changes it to only set the relationship to "001" if the relationship was not already set.  If it was already set, then it is left alone.  If there are parents of parents that are dynamically loaded, they now work.

By the way, thank you for making this library.