### PR TITLE
Continue dragging the orgchart if the mouse leaves the limits of the chart

### DIFF
--- a/dist/js/jquery.orgchart.js
+++ b/dist/js/jquery.orgchart.js
@@ -213,7 +213,7 @@
         } else if (e.targetTouches.length > 1) {
           return;
         }
-        $(document).on('mousemove touchmove',function(e) {
+        $(document).on('mousemove.OrgChart touchmove.OrgChart',function(e) {
           if (!$this.data('panning')) {
             return;
           }
@@ -248,9 +248,10 @@
           }
         });
       });
-      $(document).on('mouseup touchend',function(e) {
+      $(document).on('mouseup.OrgChart touchend.OrgChart',function(e) {
         if ($chart.data('panning')) {
-          $chart.data('panning', false).css('cursor', 'default').off('mousemove');
+          $chart.data('panning', false).css('cursor', 'default');
+          $(document).off('mousemove.OrgChart touchmove.OrgChart');
         }
       });
     }

--- a/dist/js/jquery.orgchart.js
+++ b/dist/js/jquery.orgchart.js
@@ -213,7 +213,7 @@
         } else if (e.targetTouches.length > 1) {
           return;
         }
-        $chart.on('mousemove touchmove',function(e) {
+        $(document).on('mousemove touchmove',function(e) {
           if (!$this.data('panning')) {
             return;
           }


### PR DESCRIPTION
If a user quickly drags the orgchart, so that the mouse leaves the boundaries
of the chart, the chart will stop dragging where the cursor left it.  This is
caused by the touch/mouse move events being bound to the chart, rather than the document.
By binding to the document, even if the cursor leaves the boundaries of the chart, the
chart will still be dragged to the cursors current location.