### PR TITLE
Fix a bug which prevented getChildren from working

### DIFF
--- a/dist/js/jquery.orgchart.js
+++ b/dist/js/jquery.orgchart.js
@@ -386,7 +386,7 @@
     if (relation === 'parent') {
       return $node.closest('.nodes').parent().children(':first').find('.node');
     } else if (relation === 'children') {
-      return $node.closest('table').children(':last').children().find('.node:first');
+      return $node.closest('table').find('.nodes:first').children().find('.node:first');
     } else if (relation === 'siblings') {
       return $node.closest('table').parent().siblings().find('.node:first');
     }


### PR DESCRIPTION
Because browsers insert tbody elements automatically into the table structure of
the orgchart, the getChildren function was mistakenly returning both the given
node, and the first child of said node; not the nodes children.