### PR TITLE
update jquery.orgchart.js

### DIFF
--- a/dist/js/jquery.orgchart.js
+++ b/dist/js/jquery.orgchart.js
@@ -367,6 +367,11 @@
       var lastTf = $chart.css('transform');
       var matrix = '';
       var targetScale = 1;
+      if(!opts) {
+        opts = {};
+        opts.zoomoutLimit = this.defaultOptions.zoomoutLimit;
+        opts.zoominLimit = this.defaultOptions.zoominLimit;
+      }
       if (lastTf === 'none') {
         $chart.css('transform', 'scale(' + newScale + ',' + newScale + ')');
       } else {


### PR DESCRIPTION
fix error in (missing opts.zoomoutLimit &&  opts.zoominLimit) because opts its not an object: 
if (targetScale > opts.zoomoutLimit && targetScale < opts.zoominLimit) {

}