### PR TITLE
Create Node fix for older Jquery Version

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -687,9 +687,11 @@
     // create node
     createNode: function (nodeData, level, opts) {
       var that = this;
-      $.each(nodeData.children, function (index, child) {
-        child.parentId = nodeData.id;
-      });
+      if (nodeData.children) {
+            $.each(nodeData.children, function (index, child) {
+              child.parentId = nodeData.id;
+            });
+      }
       var dtd = $.Deferred();
       // construct the content of node
       var $nodeDiv = $('<div' + (opts.draggable ? ' draggable="true"' : '') + (nodeData[opts.nodeId] ? ' id="' + nodeData[opts.nodeId] + '"' : '') + (nodeData.parentId ? ' data-parent="' + nodeData.parentId + '"' : '') + '>')


### PR DESCRIPTION
 $.each(nodeData.children) throws error on old versions of jquery when a child node has no more children.