### PR TITLE
fix bug when set the zoom for "b2t"

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -370,12 +370,12 @@
       } else {
         matrix = lastTf.split(',');
         if (lastTf.indexOf('3d') === -1) {
-          targetScale = window.parseFloat(matrix[3]) * newScale;
+          targetScale = Math.abs(window.parseFloat(matrix[3]) * newScale);
           if (targetScale > opts.zoomoutLimit && targetScale < opts.zoominLimit) {
             $chart.css('transform', lastTf + ' scale(' + newScale + ',' + newScale + ')');
           }
         } else {
-          targetScale = window.parseFloat(matrix[1]) * newScale;
+          targetScale = Math.abs(window.parseFloat(matrix[1]) * newScale);
           if (targetScale > opts.zoomoutLimit && targetScale < opts.zoominLimit) {
             $chart.css('transform', lastTf + ' scale3d(' + newScale + ',' + newScale + ', 1)');
           }


### PR DESCRIPTION
if I set the chart with the option "b2t",  the value of "targetScale" becomes a negative number, which result in bugs when zooming.The "targetScale" must only be a positive number.