### PR TITLE
wrap() adjustment

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -1040,7 +1040,7 @@
           if (isVerticalNode) {
             $nodeWrapper.append($nodeDiv);
           }else {
-            $nodeWrapper.append($nodeDiv.wrap('<tr></tr>').wrap('<td' + (hasChildren ? ' colspan="' + $childNodes.length * 2 + '"' : '') + '></td>').closest('tr'));
+            $nodeWrapper.append($('<tr/>').append($('<td' + (hasChildren ? ' colspan="' + $childNodes.length * 2 + '"' : '') + '></td>').append($nodeDiv)));
           }
           if (callback) {
             callback();
@@ -1123,7 +1123,7 @@
       nodeData.relationship = nodeData.relationship || '001';
       $.when(this.createNode(nodeData, 0, opts || $currentRoot.closest('.orgchart').data('options')))
         .done(function($nodeDiv) {
-          $table.append($nodeDiv.removeClass('slide-up').addClass('slide-down').wrap('<tr class="hidden"></tr>').wrap('<td colspan="2"></td>').closest('tr'));
+          $table.append($('<tr class="hidden">').append($('<td colspan="2">').append($nodeDiv.removeClass('slide-up').addClass('slide-down'))));
           $table.append('<tr class="lines hidden"><td colspan="2"><div class="downLine"></div></td></tr>');
           var linesRow = '<td class="rightLine">&nbsp;</td><td class="leftLine">&nbsp;</td>';
           $table.append('<tr class="lines hidden">' + linesRow + '</tr>');

--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -1040,7 +1040,7 @@
           if (isVerticalNode) {
             $nodeWrapper.append($nodeDiv);
           }else {
-            $nodeWrapper.append($nodeDiv.wrap('<tr><td' + (hasChildren ? ' colspan="' + $childNodes.length * 2 + '"' : '') + '></td></tr>').closest('tr'));
+            $nodeWrapper.append($nodeDiv.wrap('<tr></tr>').wrap('<td' + (hasChildren ? ' colspan="' + $childNodes.length * 2 + '"' : '') + '></td>').closest('tr'));
           }
           if (callback) {
             callback();
@@ -1123,7 +1123,7 @@
       nodeData.relationship = nodeData.relationship || '001';
       $.when(this.createNode(nodeData, 0, opts || $currentRoot.closest('.orgchart').data('options')))
         .done(function($nodeDiv) {
-          $table.append($nodeDiv.removeClass('slide-up').addClass('slide-down').wrap('<tr class="hidden"><td colspan="2"></td></tr>').closest('tr'));
+          $table.append($nodeDiv.removeClass('slide-up').addClass('slide-down').wrap('<tr class="hidden"></tr>').wrap('<td colspan="2"></td>').closest('tr'));
           $table.append('<tr class="lines hidden"><td colspan="2"><div class="downLine"></div></td></tr>');
           var linesRow = '<td class="rightLine">&nbsp;</td><td class="leftLine">&nbsp;</td>';
           $table.append('<tr class="lines hidden">' + linesRow + '</tr>');


### PR DESCRIPTION
Fix issues with having multiple elements in a single wrap statement on some platforms.

When using this library on some platforms (salesforce lightning being the one I found the bug) having multiple elements inside a single wrap statement results in the wrapped content only being inside the outermost element.  This was causing the nodes with children to appear to the right of all the nodes under them rather than centered at the line for the node.  Simply changing this to two wrap statements fixed the issue.  Not sure if this is an issue localized to salesforce or if there are other platforms that potentially have it.