### PR TITLE
current scale calculation fix

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -308,20 +308,19 @@
     setChartScale: function ($chart, newScale) {
       var opts = $chart.data('options');
       var lastTf = $chart.css('transform');
-      var matrix = '';
-      var targetScale = 1;
       if (lastTf === 'none') {
         $chart.css('transform', 'scale(' + newScale + ',' + newScale + ')');
       } else {
-        matrix = lastTf.split(',');
-        if (lastTf.indexOf('3d') === -1) {
-          targetScale = Math.abs(window.parseFloat(matrix[3]) * newScale);
-          if (targetScale > opts.zoomoutLimit && targetScale < opts.zoominLimit) {
+        var matrix = lastTf.split('(')[1]
+          .split(')')[0]
+          .split(',');
+        
+        var currentScale = Math.sqrt(matrix[0] * matrix[0] + matrix[1] * matrix[1]);
+        var targetScale = Math.abs(currentScale * newScale);
+        if (targetScale > opts.zoomoutLimit && targetScale < opts.zoominLimit) {
+          if (lastTf.indexOf('3d') === -1) {
             $chart.css('transform', lastTf + ' scale(' + newScale + ',' + newScale + ')');
-          }
-        } else {
-          targetScale = Math.abs(window.parseFloat(matrix[1]) * newScale);
-          if (targetScale > opts.zoomoutLimit && targetScale < opts.zoominLimit) {
+          } else {
             $chart.css('transform', lastTf + ' scale3d(' + newScale + ',' + newScale + ', 1)');
           }
         }


### PR DESCRIPTION
Hi **dabeng**!

I corrected the calculation of the current zoom range, the current implementation does not work for all cases.

For example, for an element with the style `transform: rotate (90deg) translateY (-100%) scale (2,2);` an incorrect value is returned.

The thing is that the scale must be calculated from the transformation matrix according to the formula (matrix or matrix3d, not important):

`scale = Math.sqrt (matrix[0] * matrix[0] + matrix[1] * matrix[1]);`


**jsfiddle** for an example: https://jsfiddle.net/q4hjffwd/

Link with more detailed description about it: https://css-tricks.com/get-value-of-css-rotation-through-javascript/