### PR TITLE
Fix null deref. on adding/removing/dragging nodes

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -658,7 +658,10 @@
     },
     // whether the cursor is hovering over the node
     isInAction: function ($node) {
-      return $node.children('.edge').attr('class').indexOf('fa-') > -1 ? true : false;
+      if ($node.children('.edge')[0])
+            return $node.children('.edge').attr('class').indexOf('fa-') > -1 ? true : false;
+        else
+            return false;
     },
     //
     switchVerticalArrow: function ($arrow) {


### PR DESCRIPTION
I am using OrgChart in an AngularJS SPA.  It generally works well, but when playing around with adding/removing/dragging nodes, I sometimes get null reference errors.  I don't know the root cause, but this modification certainly prevents them.  Is it any help to anyone else?  Or does it point towards where the real problem might be?