### PR TITLE
avoid earlier version (like 2.1.4) jquery throwing exception in $.each(…

### DIFF
--- a/dist/js/jquery.orgchart.js
+++ b/dist/js/jquery.orgchart.js
@@ -685,9 +685,11 @@
     // create node
     createNode: function (nodeData, level, opts) {
       var that = this;
-      $.each(nodeData.children, function (index, child) {
-        child.parentId = nodeData.id;
-      });
+      if (nodeData.children && nodeData.length) {
+        $.each(nodeData.children, function (index, child) {
+          child.parentId = nodeData.id;
+        });
+      }
       var dtd = $.Deferred();
       // construct the content of node
       var $nodeDiv = $('<div' + (opts.draggable ? ' draggable="true"' : '') + (nodeData[opts.nodeId] ? ' id="' + nodeData[opts.nodeId] + '"' : '') + (nodeData.parentId ? ' data-parent="' + nodeData.parentId + '"' : '') + '>')

--- a/src/jquery.orgchart.js
+++ b/src/jquery.orgchart.js
@@ -685,9 +685,11 @@
     // create node
     createNode: function (nodeData, level, opts) {
       var that = this;
-      $.each(nodeData.children, function (index, child) {
-        child.parentId = nodeData.id;
-      });
+      if (nodeData.children && nodeData.length) {
+        $.each(nodeData.children, function (index, child) {
+          child.parentId = nodeData.id;
+        });
+      }
       var dtd = $.Deferred();
       // construct the content of node
       var $nodeDiv = $('<div' + (opts.draggable ? ' draggable="true"' : '') + (nodeData[opts.nodeId] ? ' id="' + nodeData[opts.nodeId] + '"' : '') + (nodeData.parentId ? ' data-parent="' + nodeData.parentId + '"' : '') + '>')


### PR DESCRIPTION
…) method which access nodeData.length without check if nodeData is valid

This is jquery each  function in 2.1.4:
	each: function( obj, callback, args ) {
		var value,
			i = 0,
			length = obj.length, //<<<< could throw error if obj is null
			isArray = isArraylike( obj );
