### PR TITLE
Allow custom data in ul datasource

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -344,9 +344,9 @@
         'name': $li.contents().eq(0).text().trim(),
         'relationship': ($li.parent().parent().is('li') ? '1': '0') + ($li.siblings('li').length ? 1: 0) + ($li.children('ul').length ? 1 : 0)
       };
-      if ($li.attr('data-id')) {
-        subObj.id = $li.attr('data-id');
-      }
+      $.each($li.data(), function(key, value) {
+         subObj[key] = value;
+      });
       $li.children('ul').children().each(function() {
         if (!subObj.children) { subObj.children = []; }
         subObj.children.push(that.buildJsonDS($(this)));


### PR DESCRIPTION
Adds support for custom data attributes in ul datasource. This allows to pass additional data to the custom node template, while still using the simple format of the ul datasource.

Usage example:

HTML:
```
<ul id="org" style="display:none">
<li data-content="Additional content for node 1" data-link="http://example.com">Node 1</li>
<li data-content="Additional content for node 2" data-link="http://example.com">Node 2</li>
</ul>
```

JS:
```
var nodeTemplate = function(data) {
	return `
		<div class="title"><a href="${data.link}">${data.name}</a></div>
		<div class="content"><a href="${data.link}">${data.content}</a></div>
	`;
};

$('#orgChart').orgchart({
	'data' : $('#org'),
	'nodeTemplate': nodeTemplate
});
```

