### PR TITLE
Fixing Remove vertical node

### DIFF
--- a/dist/js/jquery.orgchart.js
+++ b/dist/js/jquery.orgchart.js
@@ -1336,9 +1336,10 @@
     },
     //
     removeNodes: function ($node) {
-      var $parent = $node.closest('table').parent();
-      var $sibs = $parent.parent().siblings();
-      if ($parent.is('td')) {
+      var isVerticalNode = $node.parents('.verticalNodes').length > 0 ? true : false
+      var $parent = isVerticalNode ? $node.parent() : $node.closest('table').parent();
+      var $sibs = isVerticalNode ? $parent.siblings() : $parent.parent().siblings();
+      if ($parent.is('td') || $parent.is('li')) {
         if (this.getNodeState($node, 'siblings').exist) {
           $sibs.eq(2).children('.topLine:lt(2)').remove();
           $sibs.slice(0, 2).children().attr('colspan', $sibs.eq(2).children().length);


### PR DESCRIPTION
I have been facing an issue on Remove from Vertical Node. 
Every time I remove a node that was in a Vertical branch, it actually removes the full branch. 
However I don't want to `oc.init()` every time the user removes a node. 
So I did a fix, so the function `removeNodes()` also can remove correctly in Vertical Nodes. 