### PR TITLE
Fixing disappearance of node from org chart on drag and drop of node on self in IE and Edge

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -973,7 +973,7 @@
         //to fix drag and drop on IE and Edge		
         event.preventDefault();
       }
-	  },
+    },
     //
     dragendHandler: function (event) {
       this.$chart.find('.allowedDrop').removeClass('allowedDrop');

--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -966,11 +966,14 @@
     },
     //
     dragoverHandler: function (event) {
-      event.preventDefault();
       if (!$(event.delegateTarget).is('.allowedDrop')) {
         event.originalEvent.dataTransfer.dropEffect = 'none';
+      } else {
+        // default action for drag-and-drop of div is not to drop, so preventing default action for nodes which have allowedDrop class
+        //to fix drag and drop on IE and Edge		
+        event.preventDefault();
       }
-    },
+	  },
     //
     dragendHandler: function (event) {
       this.$chart.find('.allowedDrop').removeClass('allowedDrop');


### PR DESCRIPTION
Bug: On drag and drop of a node on itself in IE and Edge, the node disappears from the canvas, instead of preventing the drop from taking place.
Fix: We must cancel the default action for ondragover in order for ondrop to fire. In the case of a div, the default action is not to drop. In order to allow a drag-and-drop action on a div, we must cancel the default action. Earlier we were using event.preventDefault() for all cases, now limiting this action to cases only when drop is allowed has fixed the issue.