### PR TITLE
added support for deferred in ajaxURLS

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -733,11 +733,17 @@
       $(event.delegateTarget).addClass('focused');
     },
     // load new nodes by ajax
-    loadNodes: function (rel, url, $edge) {
+      loadNodes: function (rel, url, $edge) {
       var that = this;
       var opts = this.options;
-      $.ajax({ 'url': url, 'dataType': 'json' })
-      .done(function (data) {
+      var def = null;
+      if(url.done){
+        def = url
+      }
+      else{
+        def = $.ajax({ 'url': url, 'dataType': 'json' })
+      }
+      def.done(function (data) {
         if (that.$chart.data('inAjax')) {
           if (rel === 'parent') {
             if (!$.isEmptyObject(data)) {


### PR DESCRIPTION
this pull request will detect if an ajax url is a deferred (simply checking if it has a .done property) and if so, will use that to load children; this would allow for more flexibility when pulling relations from api that does not support the format of orgChart; exemple of use: 

```js
 ajaxURL: {
                    'children': function (nodeData) {

                        var def = $.Deferred();
                        remoteSource.GetChildren(nodeData).done(function (data) {

                            var mapped = data.map(function (item) {
                                return { //map source data with orgchart format
                                    _person: item,
                                    id: item.pr_p_id_child,
                                    nodeTtitle: item.name,
                                    nodeContent: ''
                                };
                            });
                            def.resolve({ children: mapped });
                        });
                        return def;
                    },
	}
```