### PR TITLE
Add events for ajax insert, show and hide

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -122,6 +122,18 @@
       });
       mo.observe(this.$chartContainer[0], { childList: true });
     },
+    triggerInsertEvent: function (edge,rel) {
+      var initEvent = $.Event('insert.orgchart.'+rel);
+      edge.trigger(initEvent);
+    },
+    triggerShowEvent: function (edge,rel) {
+      var initEvent = $.Event('show.orgchart.'+rel);
+      edge.trigger(initEvent);
+    },
+    triggerHideEvent: function (edge,rel) {
+      var initEvent = $.Event('hide.orgchart.'+rel);
+      edge.trigger(initEvent);
+    },
     //
     attachExportButton: function () {
       var that = this;
@@ -761,6 +773,7 @@
           } else {
             that.addSiblings($edge.parent(), data.siblings ? data.siblings : data);
           }
+          that.triggerInsertEvent($edge.parent(),rel);
         }
       })
       .fail(function () {
@@ -793,8 +806,10 @@
         if (parentState.visible) {
           this.hideParent($node);
           $parent.one('transitionend', { 'topEdge': $topEdge }, this.HideFirstParentEnd.bind(this));
+          this.triggerHideEvent($node,'parent');
         } else { // show the ancestors and siblings
           this.showParent($node);
+          this.triggerShowEvent($node,'parent');
         }
       } else { // load the new parent node of the specified node by ajax request
         // start up loading status
@@ -817,8 +832,10 @@
         // hide the descendant nodes of the specified node
         if (childrenState.visible) {
           this.hideChildren($node);
+          this.triggerHideEvent($node,'children');
         } else { // show the descendants
           this.showChildren($node);
+          this.triggerShowEvent($node,'children');
         }
       } else { // load the new children nodes of the specified node by ajax request
         if (this.startLoading($bottomEdge)) {
@@ -844,21 +861,27 @@
           if ($hEdge.is('.leftEdge')) {
             if ($prevSib.is('.hidden')) {
               this.showSiblings($node, 'left');
+              this.triggerShowEvent($node,'siblings');
             } else {
               this.hideSiblings($node, 'left');
+              this.triggerHideEvent($node,'siblings');
             }
           } else {
             if ($nextSib.is('.hidden')) {
               this.showSiblings($node, 'right');
+              this.triggerShowEvent($node,'siblings');
             } else {
               this.hideSiblings($node, 'right');
+              this.triggerHideEvent($node,'siblings');
             }
           }
         } else {
           if (siblingsState.visible) {
             this.hideSiblings($node);
+            this.triggerHideEvent($node,'siblings');
           } else {
             this.showSiblings($node);
+            this.triggerShowEvent($node,'siblings');
           }
         }
       } else {


### PR DESCRIPTION
Added new events:

`insert.orgchart.<relation>`: triggered on a node after the onDemand loading completes.
`show.orgchart.<relation>`: triggered when related nodes of a node become visible.
`hide.orgchart.<relation>`: triggered when related nodes of a node are collapsed.

`<relation>` can be either `parent`, `children` or `siblings`