### PR TITLE
fix drag and drop zoom error with ghostnode selector

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -967,7 +967,8 @@
         ghostNode.appendChild(nodeCover);
         $nodeDiv.closest('.orgchart').append(ghostNode);
       } else {
-        ghostNode = $nodeDiv.closest('.orgchart').children('.ghost-node').get(0);
+        var $orgchart = $nodeDiv.closest('.orgchart');
+        ghostNode = $orgchart[0].querySelector('.ghost-node');
         nodeCover = $(ghostNode).children().get(0);
       }
       var transValues = $nodeDiv.closest('.orgchart').css('transform').split(',');


### PR DESCRIPTION
When zoom is enabled and you try to drag-and-drop a node, the second time you do this you get an error complaining about setAttribute for the ghostnode (since it's null). It seems like the selector that was there previously wasn't successfully grabbing the svg ghostnode. 

This change should fix:
https://github.com/dabeng/OrgChart/issues/89

And possibly also:
https://github.com/dabeng/OrgChart/issues/365