### PR TITLE
fix: option toggleSiblingsResp

### DIFF
--- a/src/js/jquery.orgchart.js
+++ b/src/js/jquery.orgchart.js
@@ -736,8 +736,8 @@
       } else {
         var $sibs = $node.parent().siblings();
         var sibsVisible = $sibs.length ? !$sibs.is('.hidden') : false;
-        $node.children('.leftEdge').toggleClass('oci-chevron-right', sibsVisible).toggleClass('oci-chevron-left', !sibsVisible);
-        $node.children('.rightEdge').toggleClass('oci-chevron-left', sibsVisible).toggleClass('oci-chevron-right', !sibsVisible);
+        $node.children('.leftEdge').toggleClass('oci-chevron-left', !sibsVisible);
+        $node.children('.rightEdge').toggleClass('oci-chevron-right', !sibsVisible);
       }
     },
     //


### PR DESCRIPTION
When option toggleSiblingsResp is set to true, is has no effect on the arrows behavior.

This change should fix: #613 